### PR TITLE
Show channel icons throughout TV UI

### DIFF
--- a/app/src/main/java/cz/preclikos/tvhstream/core/IconResolver.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/core/IconResolver.kt
@@ -1,14 +1,11 @@
 package cz.preclikos.tvhstream.core
 
 /**
- * Resolves the Coil model used to load a channel icon over the *pure HTSP* transport.
+ * Resolves the Coil model used to load a channel icon.
  *
  * TVHeadend may report a channel icon either as a server-relative path
- * (e.g. `imagecache/123`, `picon/...`) which we can open through HTSP, or as a raw
- * `http(s)://` URL (a "User icon"). This is an HTSP-only client by design, so raw
- * remote URLs are intentionally NOT fetched over HTTP — they resolve to `null` and
- * the UI falls back to the placeholder. To get such icons to show, enable
- * TVHeadend's imagecache so the icon is served as an HTSP-openable path instead.
+ * (e.g. `imagecache/123`, `picon/...`) which we open through HTSP, or as an
+ * `http(s)://` URL from the channel's "User icon" field which Coil loads directly.
  */
 fun resolvePiconModel(serverTag: String, piconPath: String?): String? {
     if (serverTag.isBlank() || piconPath.isNullOrBlank()) return null
@@ -17,7 +14,7 @@ fun resolvePiconModel(serverTag: String, piconPath: String?): String? {
     if (trimmed.startsWith("http://", ignoreCase = true) ||
         trimmed.startsWith("https://", ignoreCase = true)
     ) {
-        return null
+        return trimmed
     }
 
     val p = trimmed.trimStart('/')

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/components/ChannelRow.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/components/ChannelRow.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
 
 @Composable
 fun ChannelRow(
@@ -36,6 +37,8 @@ fun ChannelRow(
     name: String,
     programTitle: String,
     progress: Float?,
+    imageLoader: ImageLoader,
+    piconPath: String?,
     focused: Boolean,
     onFocus: () -> Unit,
     onConfirm: () -> Unit
@@ -84,6 +87,16 @@ fun ChannelRow(
             )
 
             Spacer(Modifier.width(6.dp))
+
+            PiconBox(
+                imageLoader = imageLoader,
+                piconPath = piconPath,
+                modifier = Modifier
+                    .width(52.dp)
+                    .height(38.dp),
+            )
+
+            Spacer(Modifier.width(10.dp))
 
             Column(Modifier.weight(1f)) {
                 Text(

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/components/PiconBox.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/components/PiconBox.kt
@@ -1,14 +1,18 @@
 package cz.preclikos.tvhstream.ui.components
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.LiveTv
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
 import coil3.compose.SubcomposeAsyncImage
@@ -23,29 +27,41 @@ data class HtspPiconData(
 fun PiconBox(
     imageLoader: ImageLoader,
     serverTag: String = "default",
-    piconPath: String?
+    piconPath: String?,
+    modifier: Modifier = Modifier
+        .width(92.dp)
+        .height(64.dp),
 ) {
     val piconUrl = remember(serverTag, piconPath) {
         cz.preclikos.tvhstream.core.resolvePiconModel(serverTag, piconPath)
     }
 
     Box(
-        modifier = Modifier
-            .width(92.dp)
-            .height(64.dp),
+        modifier = modifier,
         contentAlignment = Alignment.Center
     ) {
         if (piconUrl == null) {
-            Text("📺", style = MaterialTheme.typography.displayMedium)
+            PiconPlaceholder()
         } else {
             SubcomposeAsyncImage(
                 model = piconUrl,
                 imageLoader = imageLoader,
                 contentDescription = null,
-                loading = { Text("📺", style = MaterialTheme.typography.displayMedium) },
-                error = { Text("📺", style = MaterialTheme.typography.displayMedium) }
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxSize(),
+                loading = { PiconPlaceholder() },
+                error = { PiconPlaceholder() }
             )
         }
     }
 }
 
+@Composable
+private fun PiconPlaceholder() {
+    Icon(
+        imageVector = Icons.Outlined.LiveTv,
+        contentDescription = null,
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        modifier = Modifier.fillMaxSize(0.5f),
+    )
+}

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/player/ChannelDrawer.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/player/ChannelDrawer.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import coil3.ImageLoader
 import cz.preclikos.tvhstream.R
 import cz.preclikos.tvhstream.htsp.ChannelUi
 import cz.preclikos.tvhstream.ui.common.progress
@@ -46,6 +47,7 @@ fun ChannelDrawer(
     selectedId: Int,
     nowSec: Long,
     channelsVm: ChannelsViewModel,
+    imageLoader: ImageLoader,
     onFocusChannel: (Int) -> Unit,
     onPickChannel: (ChannelUi) -> Unit,
     focusRequester: FocusRequester,
@@ -121,6 +123,8 @@ fun ChannelDrawer(
                     name = ch.name,
                     programTitle = now?.title ?: stringResource(R.string.no_epg),
                     progress = if (now != null) prog else null,
+                    imageLoader = imageLoader,
+                    piconPath = ch.icon,
                     focused = isSelected,
                     onFocus = { if (!isRestoring) onFocusChannel(ch.id) },
                     onConfirm = { onPickChannel(ch) }

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/player/OverlayControlsTv.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/player/OverlayControlsTv.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.VolumeUp
 import androidx.compose.material.icons.filled.Stop
@@ -41,6 +42,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.media3.common.Player
+import coil3.ImageLoader
 import cz.preclikos.tvhstream.R
 import cz.preclikos.tvhstream.htsp.EpgEventEntry
 import cz.preclikos.tvhstream.settings.AspectRatioMode
@@ -48,11 +50,14 @@ import cz.preclikos.tvhstream.ui.common.formatClock
 import cz.preclikos.tvhstream.ui.common.formatHms
 import cz.preclikos.tvhstream.ui.common.progress
 import cz.preclikos.tvhstream.ui.components.RoundIconButton
+import cz.preclikos.tvhstream.ui.components.PiconBox
 
 @Composable
 fun OverlayControlsTv(
     player: Player,
+    imageLoader: ImageLoader,
     channelName: String,
+    piconPath: String?,
     nowEvent: EpgEventEntry?,
     nextEvent: EpgEventEntry?,
     nowSec: Long,
@@ -108,6 +113,17 @@ fun OverlayControlsTv(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.Top
             ) {
+                PiconBox(
+                    imageLoader = imageLoader,
+                    piconPath = piconPath,
+                    modifier = Modifier
+                        .width(96.dp)
+                        .height(68.dp)
+                        .padding(6.dp),
+                )
+
+                Spacer(Modifier.width(14.dp))
+
                 Column(Modifier.weight(1f)) {
                     Text(
                         text = title,

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/player/VideoPlayerScreen.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/player/VideoPlayerScreen.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
+import coil3.ImageLoader
 import cz.preclikos.tvhstream.htsp.ConnectionState
 import cz.preclikos.tvhstream.settings.AspectRatioMode
 import cz.preclikos.tvhstream.settings.PlayerSettings
@@ -78,6 +79,7 @@ fun VideoPlayerScreen(
     selection: ChannelSelectionStore = koinInject(),
     settingsStore: PlayerSettingsStore = koinInject(),
     channelsVm: ChannelsViewModel = koinViewModel(),
+    imageLoader: ImageLoader = koinInject(),
     channelId: Int,
     channelName: String,
     serviceId: Int,
@@ -176,6 +178,9 @@ fun VideoPlayerScreen(
 
     val nowEvent = remember(epg, nowSec) { epg.nowEvent(nowSec) }
     val nextEvent = remember(epg, nowEvent) { epg.nextAfter(nowEvent) }
+    val currentChannel = remember(channels, currentChannelId) {
+        channels.firstOrNull { it.id == currentChannelId }
+    }
 
 
     LaunchedEffect(controlsVisible) {
@@ -310,6 +315,7 @@ fun VideoPlayerScreen(
                 selectedId = selectedId,
                 nowSec = nowSec,
                 channelsVm = channelsVm,
+                imageLoader = imageLoader,
                 onFocusChannel = { selectedId = it },
                 onPickChannel = {
                     selection.setSelected(it.id)
@@ -335,7 +341,9 @@ fun VideoPlayerScreen(
         ) {
             OverlayControlsTv(
                 player = player,
+                imageLoader = imageLoader,
                 channelName = currentChannelName,
+                piconPath = currentChannel?.icon,
                 nowEvent = nowEvent,
                 nextEvent = nextEvent,
                 nowSec = nowSec,

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/screens/ChannelsScreen.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/screens/ChannelsScreen.kt
@@ -162,6 +162,8 @@ fun ChannelsScreen(
                             name = ch.name,
                             programTitle = now?.title ?: stringResource(R.string.no_epg),
                             progress = if (now != null) prog else null,
+                            imageLoader = imageLoader,
+                            piconPath = ch.icon,
                             focused = isSelected,
                             onFocus = {
                                 if (!isRestoring) selection.setSelected(ch.id)

--- a/app/src/test/java/cz/preclikos/tvhstream/core/IconResolverTest.kt
+++ b/app/src/test/java/cz/preclikos/tvhstream/core/IconResolverTest.kt
@@ -20,11 +20,19 @@ class IconResolverTest {
     }
 
     @Test
-    fun rawHttpUrls_areNotFetched_overPureHtsp() {
-        // Pure-HTSP client: raw remote URLs resolve to null (placeholder), never HTTP.
-        assertNull(resolvePiconModel("default", "http://host/icon.png"))
-        assertNull(resolvePiconModel("default", "https://host/icon.png"))
-        assertNull(resolvePiconModel("default", "HTTPS://HOST/icon.png"))
+    fun rawHttpUrls_areLoadedDirectly() {
+        assertEquals(
+            "http://host/icon.png",
+            resolvePiconModel("default", "http://host/icon.png")
+        )
+        assertEquals(
+            "https://host/icon.png",
+            resolvePiconModel("default", " https://host/icon.png ")
+        )
+        assertEquals(
+            "HTTPS://HOST/icon.png",
+            resolvePiconModel("default", "HTTPS://HOST/icon.png")
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary
- load HTTP(S) channel User icon URLs directly while preserving HTSP image-cache paths
- show channel icons in channel rows, the in-player drawer, and the playback overlay
- use a consistently scaled TV placeholder while icons load or are unavailable

## Testing
- `testDebugUnitTest`
- `assembleDebug`

The public checkout requires Firebase plugins to be disabled locally for these commands because it does not include `google-services.json`; no build configuration changes are included in this PR.

Closes #7