### PR TITLE
Prevent partial channel synchronization

### DIFF
--- a/app/src/main/java/cz/preclikos/tvhstream/htsp/HtspEventStream.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/htsp/HtspEventStream.kt
@@ -1,0 +1,17 @@
+package cz.preclikos.tvhstream.htsp
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+
+internal class HtspEventStream(extraBufferCapacity: Int = 256) {
+    private val mutableEvents = MutableSharedFlow<HtspEvent>(
+        extraBufferCapacity = extraBufferCapacity
+    )
+
+    val events: SharedFlow<HtspEvent> = mutableEvents.asSharedFlow()
+
+    suspend fun emit(event: HtspEvent) {
+        mutableEvents.emit(event)
+    }
+}

--- a/app/src/main/java/cz/preclikos/tvhstream/htsp/HtspService.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/htsp/HtspService.kt
@@ -48,11 +48,8 @@ class HtspService(
 
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
-    private val _controlEvents = MutableSharedFlow<HtspEvent>(
-        extraBufferCapacity = 256,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST
-    )
-    val controlEvents: SharedFlow<HtspEvent> = _controlEvents
+    private val controlEventStream = HtspEventStream()
+    val controlEvents: SharedFlow<HtspEvent> = controlEventStream.events
 
     private val _muxEvents = MutableSharedFlow<HtspMessage>(
         extraBufferCapacity = 8192,
@@ -325,7 +322,7 @@ class HtspService(
                     if (msg.method == "muxpkt") {
                         _muxEvents.tryEmit(msg)
                     } else {
-                        _controlEvents.tryEmit(HtspEvent.ServerMessage(msg))
+                        controlEventStream.emit(HtspEvent.ServerMessage(msg))
                     }
                 } catch (t: SocketTimeoutException) {
                     val now = System.currentTimeMillis()
@@ -404,7 +401,7 @@ class HtspService(
     private suspend fun failAll(t: Throwable) {
         connectMutex.withLock {
             _state.value = ConnectionState.Error(t)
-            _controlEvents.tryEmit(HtspEvent.ConnectionError(t))
+            controlEventStream.emit(HtspEvent.ConnectionError(t))
 
             val defs = pending.values.toList()
             pending.clear()

--- a/app/src/main/java/cz/preclikos/tvhstream/repositories/ChannelSnapshotStore.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/repositories/ChannelSnapshotStore.kt
@@ -1,0 +1,56 @@
+package cz.preclikos.tvhstream.repositories
+
+internal data class ChannelMetadata(
+    val id: Int,
+    val name: String,
+    val number: Int?,
+    val icon: String?
+)
+
+internal class ChannelSnapshotStore {
+    private val channels = linkedMapOf<Int, ChannelMetadata>()
+    private var initialSyncCompleted = false
+
+    val size: Int
+        get() = channels.size
+
+    fun reset() {
+        channels.clear()
+        initialSyncCompleted = false
+    }
+
+    operator fun get(id: Int): ChannelMetadata? = channels[id]
+
+    fun upsert(channel: ChannelMetadata): List<ChannelMetadata>? {
+        channels[channel.id] = channel
+        return snapshotIfReady()
+    }
+
+    fun delete(id: Int): List<ChannelMetadata>? {
+        channels.remove(id)
+        return snapshotIfReady()
+    }
+
+    fun completeInitialSync(): List<ChannelMetadata> {
+        initialSyncCompleted = true
+        return snapshot()
+    }
+
+    fun isEmpty(): Boolean = channels.isEmpty()
+
+    fun ids(): List<Int> = channels.keys.toList()
+
+    fun snapshot(): List<ChannelMetadata> = channels.values.sortedWith(channelComparator)
+
+    private fun snapshotIfReady(): List<ChannelMetadata>? =
+        if (initialSyncCompleted) snapshot() else null
+
+    private companion object {
+        val channelComparator = compareBy<ChannelMetadata>(
+            { it.number == null },
+            { it.number ?: Int.MAX_VALUE },
+            { it.name.lowercase() },
+            { it.id }
+        )
+    }
+}

--- a/app/src/main/java/cz/preclikos/tvhstream/repositories/TvhRepository.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/repositories/TvhRepository.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
@@ -119,14 +120,7 @@ class TvhRepository(
     // Channels
     // ---------------------------
 
-    private data class ChannelEntry(
-        val id: Int,
-        val name: String,
-        val number: Int?,
-        val icon: String?
-    )
-
-    private val channelMap = linkedMapOf<Int, ChannelEntry>()
+    private val channelStore = ChannelSnapshotStore()
     private val _channelsUi = MutableStateFlow<List<ChannelUi>>(emptyList())
     val channelsUi: StateFlow<List<ChannelUi>> = _channelsUi
 
@@ -164,7 +158,7 @@ class TvhRepository(
         if (started) return
         started = true
 
-        scope.launch {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
             htsp.controlEvents.collect { e ->
                 when (e) {
                     is HtspEvent.ServerMessage -> handleServerMessage(e.msg)
@@ -181,7 +175,7 @@ class TvhRepository(
 
     suspend fun onNewConnectionStarting() {
         stateMutex.withLock {
-            channelMap.clear()
+            channelStore.reset()
             _channelsUi.value = emptyList()
 
             epgByChannel.clear()
@@ -366,20 +360,13 @@ class TvhRepository(
      * Prioritize the ones with the smallest coveredTo first.
      */
     private fun pickChannelsNeedingTopUpLocked(nowSec: Long, limit: Int): List<Int> {
-        if (channelMap.isEmpty()) return emptyList()
+        if (channelStore.isEmpty()) return emptyList()
 
         val wantWarmTo = nowSec + warmupFutureSec
         val wantMinTo = nowSec + steadyMinFutureSec
 
         // Order channels by number/name, but select targets by "how far behind horizon they are"
-        val sortedIds = channelMap.values
-            .sortedWith(
-                compareBy(
-                    { it.number == null },
-                    { it.number ?: Int.MAX_VALUE },
-                    { it.name.lowercase() },
-                    { it.id })
-            )
+        val sortedIds = channelStore.snapshot()
             .map { it.id }
 
         val candidates = sortedIds.asSequence()
@@ -397,10 +384,10 @@ class TvhRepository(
     }
 
     private fun warmupProgressLocked(nowSec: Long): Pair<Int, Int> {
-        val total = channelMap.size
+        val total = channelStore.size
         if (total == 0) return 0 to 0
         val wantWarmTo = nowSec + warmupFutureSec
-        val done = channelMap.keys.count { id ->
+        val done = channelStore.ids().count { id ->
             val cov = epgCoverage[id]
             cov != null && cov.coveredTo >= wantWarmTo
         }
@@ -418,9 +405,9 @@ class TvhRepository(
 
             "initialSyncCompleted" -> {
                 val count = stateMutex.withLock {
-                    publishChannelsLocked()
+                    publishChannelsLocked(channelStore.completeInitialSync())
                     if (!channelsReadyDef.isCompleted) channelsReadyDef.complete(Unit)
-                    channelMap.size
+                    channelStore.size
                 }
                 setStatus(
                     UiText.Res(R.string.status_channels_ready, listOf(count)),
@@ -436,7 +423,7 @@ class TvhRepository(
 
     private fun handleChannelLocked(msg: HtspMessage) {
         val id = msg.int("channelId") ?: return
-        val existing = channelMap[id]
+        val existing = channelStore[id]
         val isNew = existing == null
 
         val name = msg.str("channelName") ?: existing?.name ?: return
@@ -448,12 +435,12 @@ class TvhRepository(
             ?: existing?.number
         val icon = msg.str("channelIcon") ?: existing?.icon
 
-        channelMap[id] = ChannelEntry(id, name, number, icon)
+        val snapshot = channelStore.upsert(ChannelMetadata(id, name, number, icon))
         epgCoverage.getOrPut(id) { EpgCoverage() }
 
-        publishChannelsLocked()
+        snapshot?.let(::publishChannelsLocked)
         setStatusThrottled(
-            UiText.Res(R.string.status_syncing_channels, listOf(channelMap.size)),
+            UiText.Res(R.string.status_syncing_channels, listOf(channelStore.size)),
             StatusSlot.SYNC,
             minIntervalMs = 700
         )
@@ -466,29 +453,19 @@ class TvhRepository(
     private fun handleChannelDeleteLocked(msg: HtspMessage) {
         val id = msg.int("channelId") ?: return
 
-        channelMap.remove(id)
+        val snapshot = channelStore.delete(id)
         epgByChannel.remove(id)
         epgCoverage.remove(id)
         epgInFlight.remove(id)
 
-        publishChannelsLocked()
+        snapshot?.let(::publishChannelsLocked)
     }
 
-    private fun publishChannelsLocked() {
-        val sorted = channelMap.values
-            .sortedWith(
-                compareBy(
-                    { it.number == null },
-                    { it.number ?: Int.MAX_VALUE },
-                    { it.name.lowercase() },
-                    { it.id })
-            )
-            .map { ChannelUi(it.id, formatName(it), it.icon) }
-
-        _channelsUi.value = sorted
+    private fun publishChannelsLocked(channels: List<ChannelMetadata>) {
+        _channelsUi.value = channels.map { ChannelUi(it.id, formatName(it), it.icon) }
     }
 
-    private fun formatName(c: ChannelEntry): String =
+    private fun formatName(c: ChannelMetadata): String =
         if (c.number != null) "${c.number}  ${c.name}" else c.name
 
     // ---------------------------

--- a/app/src/test/java/cz/preclikos/tvhstream/htsp/HtspEventStreamTest.kt
+++ b/app/src/test/java/cz/preclikos/tvhstream/htsp/HtspEventStreamTest.kt
@@ -1,0 +1,39 @@
+package cz.preclikos.tvhstream.htsp
+
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class HtspEventStreamTest {
+
+    @Test
+    fun emit_doesNotDropEventsWhenTheCollectorIsSlowerThanTheProducer() = runBlocking {
+        val stream = HtspEventStream(extraBufferCapacity = 1)
+        val received = mutableListOf<Int>()
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) {
+            stream.events.take(3).collect { event ->
+                delay(10)
+                received += (event as HtspEvent.ServerMessage).msg.int("value")!!
+            }
+        }
+
+        repeat(3) { value ->
+            stream.emit(serverEvent(value))
+        }
+        collector.join()
+
+        assertEquals(listOf(0, 1, 2), received)
+    }
+
+    private fun serverEvent(value: Int) = HtspEvent.ServerMessage(
+        HtspMessage(
+            method = "test",
+            seq = null,
+            fields = mapOf("value" to value)
+        )
+    )
+}

--- a/app/src/test/java/cz/preclikos/tvhstream/repositories/ChannelSnapshotStoreTest.kt
+++ b/app/src/test/java/cz/preclikos/tvhstream/repositories/ChannelSnapshotStoreTest.kt
@@ -1,0 +1,47 @@
+package cz.preclikos.tvhstream.repositories
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChannelSnapshotStoreTest {
+
+    @Test
+    fun initialSync_publishesOnlyTheCompleteSortedSnapshot() {
+        val store = ChannelSnapshotStore()
+
+        assertNull(store.upsert(channel(id = 30, name = "Thirty", number = 30)))
+        assertNull(store.upsert(channel(id = 10, name = "Ten", number = 10)))
+        assertNull(store.upsert(channel(id = 20, name = "Twenty", number = 20)))
+
+        assertEquals(listOf(10, 20, 30), store.completeInitialSync().map { it.id })
+    }
+
+    @Test
+    fun changesAfterInitialSync_publishUpdatedSnapshots() {
+        val store = ChannelSnapshotStore()
+        store.upsert(channel(id = 10, name = "Ten", number = 10))
+        store.completeInitialSync()
+
+        val added = store.upsert(channel(id = 20, name = "Twenty", number = 20))
+        val deleted = store.delete(10)
+
+        assertEquals(listOf(10, 20), added?.map { it.id })
+        assertEquals(listOf(20), deleted?.map { it.id })
+    }
+
+    @Test
+    fun reset_stagesTheNextConnectionUntilItsInitialSyncCompletes() {
+        val store = ChannelSnapshotStore()
+        store.upsert(channel(id = 10, name = "Ten", number = 10))
+        store.completeInitialSync()
+
+        store.reset()
+
+        assertNull(store.upsert(channel(id = 40, name = "Forty", number = 40)))
+        assertEquals(listOf(40), store.completeInitialSync().map { it.id })
+    }
+
+    private fun channel(id: Int, name: String, number: Int) =
+        ChannelMetadata(id = id, name = name, number = number, icon = null)
+}


### PR DESCRIPTION
## Summary
- deliver HTSP control events without dropping them when consumers are slower than the socket reader
- stage channel metadata until `initialSyncCompleted`, then publish one complete sorted snapshot
- continue publishing incremental channel updates after the initial sync

This prevents incomplete channel lists when a server sends more metadata events than the control-flow buffer can absorb during startup. Media packet buffering remains unchanged.

## Verification
- focused `HtspEventStreamTest` and `ChannelSnapshotStoreTest`
- full `testDebugUnitTest`
- `assembleDebug`

The public checkout has no `google-services.json`, so Firebase plugins/dependencies were disabled only for local verification and restored before committing.

Closes #16