### PR TITLE
Support physical channel up and down keys

### DIFF
--- a/app/src/main/java/cz/preclikos/tvhstream/core/ChannelNavigation.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/core/ChannelNavigation.kt
@@ -1,0 +1,25 @@
+package cz.preclikos.tvhstream.core
+
+import android.view.KeyEvent
+
+object ChannelNavigation {
+    fun directionForKeyCode(keyCode: Int): Int? = when (keyCode) {
+        KeyEvent.KEYCODE_CHANNEL_UP -> 1
+        KeyEvent.KEYCODE_CHANNEL_DOWN -> -1
+        else -> null
+    }
+
+    fun adjacentId(
+        orderedIds: List<Int>,
+        currentId: Int,
+        direction: Int,
+    ): Int? {
+        if (orderedIds.isEmpty()) return null
+
+        val currentIndex = orderedIds.indexOf(currentId)
+        if (currentIndex < 0) return orderedIds.first()
+
+        val offset = if (direction < 0) -1 else 1
+        return orderedIds[Math.floorMod(currentIndex + offset, orderedIds.size)]
+    }
+}

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/player/VideoPlayerScreen.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/player/VideoPlayerScreen.kt
@@ -42,6 +42,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
+import cz.preclikos.tvhstream.core.ChannelNavigation
+import cz.preclikos.tvhstream.htsp.ChannelUi
 import cz.preclikos.tvhstream.htsp.ConnectionState
 import cz.preclikos.tvhstream.settings.AspectRatioMode
 import cz.preclikos.tvhstream.settings.PlayerSettings
@@ -158,6 +160,30 @@ fun VideoPlayerScreen(
         controlsVisible = false
     }
 
+    fun tuneChannel(channel: ChannelUi): Boolean {
+        selection.setSelected(channel.id)
+        selectedId = channel.id
+
+        currentChannelId = channel.id
+        currentServiceId = channel.id
+        currentChannelName = channel.name
+
+        drawerOpen = false
+        showControls()
+        return true
+    }
+
+    fun tuneAdjacentChannel(direction: Int): Boolean {
+        val adjacentId = ChannelNavigation.adjacentId(
+            orderedIds = channels.map { it.id },
+            currentId = currentChannelId,
+            direction = direction,
+        ) ?: return false
+
+        val channel = channels.firstOrNull { it.id == adjacentId } ?: return false
+        return tuneChannel(channel)
+    }
+
     LaunchedEffect(controlsVisible, interactionToken) {
         if (!controlsVisible) return@LaunchedEffect
         delay(autoHideMs)
@@ -220,6 +246,10 @@ fun VideoPlayerScreen(
             .background(Color.Black)
             .onPreviewKeyEvent { event ->
                 if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+
+                ChannelNavigation.directionForKeyCode(event.nativeKeyEvent.keyCode)?.let { direction ->
+                    return@onPreviewKeyEvent tuneAdjacentChannel(direction)
+                }
 
                 if (showDrawer) {
                     return@onPreviewKeyEvent when (event.key) {
@@ -311,17 +341,7 @@ fun VideoPlayerScreen(
                 nowSec = nowSec,
                 channelsVm = channelsVm,
                 onFocusChannel = { selectedId = it },
-                onPickChannel = {
-                    selection.setSelected(it.id)
-                    selectedId = it.id
-
-                    currentChannelId = it.id
-                    currentServiceId = it.id
-                    currentChannelName = it.name
-
-                    drawerOpen = false
-                    showControls()
-                },
+                onPickChannel = { tuneChannel(it) },
                 focusRequester = drawerFocus,
                 onCloseDrawer = { drawerOpen = false },
             )

--- a/app/src/test/java/cz/preclikos/tvhstream/core/ChannelNavigationTest.kt
+++ b/app/src/test/java/cz/preclikos/tvhstream/core/ChannelNavigationTest.kt
@@ -1,0 +1,53 @@
+package cz.preclikos.tvhstream.core
+
+import android.view.KeyEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ChannelNavigationTest {
+
+    private val channels = listOf(10, 20, 30)
+
+    @Test
+    fun next_returnsFollowingChannel() {
+        assertEquals(20, ChannelNavigation.adjacentId(channels, 10, 1))
+    }
+
+    @Test
+    fun previous_returnsPrecedingChannel() {
+        assertEquals(20, ChannelNavigation.adjacentId(channels, 30, -1))
+    }
+
+    @Test
+    fun next_wrapsAfterLastChannel() {
+        assertEquals(10, ChannelNavigation.adjacentId(channels, 30, 1))
+    }
+
+    @Test
+    fun previous_wrapsBeforeFirstChannel() {
+        assertEquals(30, ChannelNavigation.adjacentId(channels, 10, -1))
+    }
+
+    @Test
+    fun staleCurrentChannel_fallsBackToFirstCurrentChannel() {
+        assertEquals(10, ChannelNavigation.adjacentId(channels, 99, 1))
+        assertEquals(10, ChannelNavigation.adjacentId(channels, 99, -1))
+    }
+
+    @Test
+    fun emptyChannelList_hasNoAdjacentChannel() {
+        assertNull(ChannelNavigation.adjacentId(emptyList(), 10, 1))
+    }
+
+    @Test
+    fun channelKeys_mapToNavigationDirection() {
+        assertEquals(1, ChannelNavigation.directionForKeyCode(KeyEvent.KEYCODE_CHANNEL_UP))
+        assertEquals(-1, ChannelNavigation.directionForKeyCode(KeyEvent.KEYCODE_CHANNEL_DOWN))
+    }
+
+    @Test
+    fun unrelatedKey_hasNoNavigationDirection() {
+        assertNull(ChannelNavigation.directionForKeyCode(KeyEvent.KEYCODE_DPAD_UP))
+    }
+}


### PR DESCRIPTION
## Summary
- handle Android TV `KEYCODE_CHANNEL_UP` and `KEYCODE_CHANNEL_DOWN` during playback
- tune through the current ordered channel list with wraparound
- share the existing tune path between remote keys and the player channel drawer
- cover direction mapping, wraparound, stale selection, and empty lists with JVM tests

## Verification
- focused `ChannelNavigationTest`
- full `testDebugUnitTest`
- `assembleDebug`

The public checkout has no `google-services.json`, so Firebase plugins/dependencies were disabled only for local verification and restored before committing.

Closes #14