### PR TITLE
Make last-played channel persistence optional

### DIFF
--- a/app/src/main/java/cz/preclikos/tvhstream/core/LastPlayedChannelPolicy.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/core/LastPlayedChannelPolicy.kt
@@ -1,0 +1,9 @@
+package cz.preclikos.tvhstream.core
+
+object LastPlayedChannelPolicy {
+    fun resolve(orderedIds: List<Int>, persistedId: Int?, enabled: Boolean): Int? {
+        if (orderedIds.isEmpty()) return null
+        if (!enabled) return orderedIds.first()
+        return persistedId?.takeIf(orderedIds::contains) ?: orderedIds.first()
+    }
+}

--- a/app/src/main/java/cz/preclikos/tvhstream/settings/PlayerSettings.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/settings/PlayerSettings.kt
@@ -1,7 +1,9 @@
 package cz.preclikos.tvhstream.settings
 
 import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import cz.preclikos.tvhstream.htsp.HtspService
@@ -16,6 +18,8 @@ data class PlayerSettings(
     val audioLanguage: String?,
     val subtitleLanguage: String?,
     val aspectRatio: AspectRatioMode = AspectRatioMode.FIT,
+    val rememberLastPlayedChannel: Boolean = false,
+    val lastPlayedChannelId: Int? = null,
 )
 
 class PlayerSettingsStore(private val context: Context) {
@@ -25,6 +29,8 @@ class PlayerSettingsStore(private val context: Context) {
         val AUDIO_LANGUAGE = stringPreferencesKey("audioLanguage")
         val SUBTITLE_LANGUAGE = stringPreferencesKey("subtitleLanguage")
         val ASPECT_RATIO = stringPreferencesKey("aspectRatio")
+        val REMEMBER_LAST_PLAYED_CHANNEL = booleanPreferencesKey("rememberLastPlayedChannel")
+        val LAST_PLAYED_CHANNEL_ID = intPreferencesKey("lastPlayedChannelId")
     }
 
     val playerSettings: Flow<PlayerSettings> =
@@ -37,7 +43,9 @@ class PlayerSettingsStore(private val context: Context) {
                 profile = p[Keys.PROFILE] ?: "",
                 audioLanguage = p[Keys.AUDIO_LANGUAGE]?.takeIf { it.isNotBlank() },
                 subtitleLanguage = p[Keys.SUBTITLE_LANGUAGE]?.takeIf { it.isNotBlank() },
-                aspectRatio = aspect
+                aspectRatio = aspect,
+                rememberLastPlayedChannel = p[Keys.REMEMBER_LAST_PLAYED_CHANNEL] ?: false,
+                lastPlayedChannelId = p[Keys.LAST_PLAYED_CHANNEL_ID],
             )
         }
 
@@ -64,6 +72,21 @@ class PlayerSettingsStore(private val context: Context) {
     suspend fun setAspectRatio(aspectRatio: AspectRatioMode) {
         context.dataStore.edit { p ->
             p[Keys.ASPECT_RATIO] = aspectRatio.name
+        }
+    }
+
+    suspend fun setRememberLastPlayedChannel(enabled: Boolean) {
+        context.dataStore.edit { p ->
+            p[Keys.REMEMBER_LAST_PLAYED_CHANNEL] = enabled
+            if (!enabled) p.remove(Keys.LAST_PLAYED_CHANNEL_ID)
+        }
+    }
+
+    suspend fun setLastPlayedChannel(channelId: Int) {
+        context.dataStore.edit { p ->
+            if (p[Keys.REMEMBER_LAST_PLAYED_CHANNEL] == true) {
+                p[Keys.LAST_PLAYED_CHANNEL_ID] = channelId
+            }
         }
     }
 }

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/player/VideoPlayerScreen.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/player/VideoPlayerScreen.kt
@@ -141,6 +141,7 @@ fun VideoPlayerScreen(
             videoPlayerViewModel.stop()
         }
         videoPlayerViewModel.playService(ctx, currentServiceId)
+        settingsStore.setLastPlayedChannel(currentChannelId)
         lastPlayedServiceId = currentServiceId
     }
 

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/screens/ChannelsScreen.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/screens/ChannelsScreen.kt
@@ -42,7 +42,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
 import cz.preclikos.tvhstream.R
+import cz.preclikos.tvhstream.core.LastPlayedChannelPolicy
 import cz.preclikos.tvhstream.htsp.EpgEventEntry
+import cz.preclikos.tvhstream.settings.PlayerSettingsStore
 import cz.preclikos.tvhstream.stores.ChannelSelectionStore
 import cz.preclikos.tvhstream.ui.common.formatHm
 import cz.preclikos.tvhstream.ui.common.progress
@@ -59,11 +61,13 @@ import org.koin.compose.koinInject
 fun ChannelsScreen(
     channelViewModel: ChannelsViewModel = koinViewModel(),
     selection: ChannelSelectionStore = koinInject(),
+    settingsStore: PlayerSettingsStore = koinInject(),
     imageLoader: ImageLoader = koinInject(),
     onPlay: (channelId: Int, serviceId: Int, channelName: String) -> Unit
 ) {
     val channels by channelViewModel.channels.collectAsState()
     val selectedId by selection.selectedId.collectAsState()
+    val playerSettings by settingsStore.playerSettings.collectAsState(initial = null)
     var didInitialRestore by remember { mutableStateOf(false) }
     var isRestoring by remember { mutableStateOf(false) }
 
@@ -88,16 +92,31 @@ fun ChannelsScreen(
         }
     }
 
-    LaunchedEffect(channels) {
-        if (channels.isEmpty()) return@LaunchedEffect
-        if (selectedId == -1) selection.setSelected(channels.first().id)
+    LaunchedEffect(channels, playerSettings) {
+        val settings = playerSettings ?: return@LaunchedEffect
+        if (selectedId != -1) return@LaunchedEffect
+
+        LastPlayedChannelPolicy.resolve(
+            orderedIds = channels.map { it.id },
+            persistedId = settings.lastPlayedChannelId,
+            enabled = settings.rememberLastPlayedChannel,
+        )?.let(selection::setSelected)
     }
 
-    LaunchedEffect(channels, selectedId) {
+    LaunchedEffect(channels, selectedId, playerSettings) {
         if (didInitialRestore) return@LaunchedEffect
         if (channels.isEmpty()) return@LaunchedEffect
+        val settings = playerSettings ?: return@LaunchedEffect
 
-        val id = if (selectedId == -1) channels.first().id else selectedId
+        val id = if (selectedId == -1) {
+            LastPlayedChannelPolicy.resolve(
+                orderedIds = channels.map { it.id },
+                persistedId = settings.lastPlayedChannelId,
+                enabled = settings.rememberLastPlayedChannel,
+            ) ?: return@LaunchedEffect
+        } else {
+            selectedId
+        }
         val idx = channels.indexOfFirst { it.id == id }
         if (idx < 0) return@LaunchedEffect
 

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/screens/settings/SettingsPlayer.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/screens/settings/SettingsPlayer.kt
@@ -2,7 +2,9 @@ package cz.preclikos.tvhstream.ui.screens.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -11,6 +13,7 @@ import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -18,6 +21,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -93,6 +97,24 @@ fun SettingsPlayer(
                     )
                 }
             }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(Modifier.weight(1f)) {
+                Text(stringResource(R.string.remember_last_played_channel))
+                Text(
+                    text = stringResource(R.string.remember_last_played_channel_summary),
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+            Switch(
+                checked = ui.rememberLastPlayedChannel,
+                onCheckedChange = vm::onRememberLastPlayedChannelChanged,
+            )
         }
 
         val err = (ui.profiles as? ProfilesUiState.Error)?.message

--- a/app/src/main/java/cz/preclikos/tvhstream/viewmodels/SettingsPlayerViewModel.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/viewmodels/SettingsPlayerViewModel.kt
@@ -27,7 +27,8 @@ sealed interface ProfilesUiState {
 data class SettingsPlayerUiState(
     val connected: Boolean = false,
     val profiles: ProfilesUiState = ProfilesUiState.Idle,
-    val selectedProfileUuid: String? = null
+    val selectedProfileUuid: String? = null,
+    val rememberLastPlayedChannel: Boolean = false,
 )
 
 class SettingsPlayerViewModel(
@@ -44,6 +45,14 @@ class SettingsPlayerViewModel(
         viewModelScope.launch {
             htsp.state.collect { st ->
                 _ui.value = _ui.value.copy(connected = st is ConnectionState.Connected)
+            }
+        }
+
+        viewModelScope.launch {
+            settingsStore.playerSettings.collect { settings ->
+                _ui.value = _ui.value.copy(
+                    rememberLastPlayedChannel = settings.rememberLastPlayedChannel
+                )
             }
         }
 
@@ -91,6 +100,13 @@ class SettingsPlayerViewModel(
 
         viewModelScope.launch {
             settingsStore.setProfile(profile.name)
+        }
+    }
+
+    fun onRememberLastPlayedChannelChanged(enabled: Boolean) {
+        _ui.value = _ui.value.copy(rememberLastPlayedChannel = enabled)
+        viewModelScope.launch {
+            settingsStore.setRememberLastPlayedChannel(enabled)
         }
     }
 

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -25,6 +25,8 @@
     <string name="profile">Profil</string>
     <string name="audio_language">Jazyk zvuku</string>
     <string name="subtitle_language">Jazyk titulků</string>
+    <string name="remember_last_played_channel">Zapamatovat poslední přehrávaný kanál</string>
+    <string name="remember_last_played_channel_summary">Po spuštění aplikace jej obnovit jako výchozí vybraný kanál.</string>
 
     <string name="loading_wait">Načítání čeká…</string>
     <string name="not_connected">Nepřipojeno</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,8 @@
     <string name="profile">Profile</string>
     <string name="audio_language">Audio Language</string>
     <string name="subtitle_language">Subtitle Language</string>
+    <string name="remember_last_played_channel">Remember last played channel</string>
+    <string name="remember_last_played_channel_summary">Restore it as the initial channel selection when the app starts.</string>
 
     <string name="loading_wait">Waiting for loading…</string>
     <string name="not_connected">Not connected</string>

--- a/app/src/test/java/cz/preclikos/tvhstream/core/LastPlayedChannelPolicyTest.kt
+++ b/app/src/test/java/cz/preclikos/tvhstream/core/LastPlayedChannelPolicyTest.kt
@@ -1,0 +1,34 @@
+package cz.preclikos.tvhstream.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LastPlayedChannelPolicyTest {
+    private val channels = listOf(10, 20, 30)
+
+    @Test
+    fun enabled_restoresPersistedCurrentChannel() {
+        assertEquals(20, LastPlayedChannelPolicy.resolve(channels, 20, enabled = true))
+    }
+
+    @Test
+    fun disabled_preservesFirstChannelDefault() {
+        assertEquals(10, LastPlayedChannelPolicy.resolve(channels, 20, enabled = false))
+    }
+
+    @Test
+    fun missingPersistedChannel_fallsBackToFirstCurrentChannel() {
+        assertEquals(10, LastPlayedChannelPolicy.resolve(channels, null, enabled = true))
+    }
+
+    @Test
+    fun stalePersistedChannel_fallsBackToFirstCurrentChannel() {
+        assertEquals(10, LastPlayedChannelPolicy.resolve(channels, 99, enabled = true))
+    }
+
+    @Test
+    fun emptyChannelList_hasNoSelection() {
+        assertNull(LastPlayedChannelPolicy.resolve(emptyList(), 20, enabled = true))
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in player setting for remembering the last played channel, defaulting to off
- persist a channel only after it has been sent to the player
- restore a valid saved channel as the initial channel-list selection
- fall back to the existing first-channel behavior when disabled, missing, or stale
- clear the saved channel when the setting is disabled

## Verification
- focused `LastPlayedChannelPolicyTest`
- full `testDebugUnitTest`
- `assembleDebug`

The public checkout has no `google-services.json`, so Firebase plugins/dependencies were disabled only for local verification and restored before committing.

Closes #18