### PR TITLE
Add German localization and language selection

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,10 +16,20 @@
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
         android:banner="@drawable/banner"
+        android:localeConfig="@xml/locales_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.TVHStream"
         android:name=".App"
         android:usesCleartextTraffic="true">
+
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
 
         <activity
             android:name=".ui.MainActivity"

--- a/app/src/main/java/cz/preclikos/tvhstream/settings/AppLanguage.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/settings/AppLanguage.kt
@@ -1,0 +1,17 @@
+package cz.preclikos.tvhstream.settings
+
+enum class AppLanguage(val languageTag: String) {
+    SYSTEM(""),
+    GERMAN("de"),
+    ENGLISH("en"),
+    CZECH("cs");
+
+    companion object {
+        fun fromLanguageTags(languageTags: String): AppLanguage {
+            val language = languageTags.substringBefore(',').substringBefore('-')
+            return entries.firstOrNull {
+                it.languageTag.isNotEmpty() && it.languageTag.equals(language, ignoreCase = true)
+            } ?: SYSTEM
+        }
+    }
+}

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/MainActivity.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/MainActivity.kt
@@ -1,10 +1,10 @@
 package cz.preclikos.tvhstream.ui
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/components/SettingsSubRail.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/components/SettingsSubRail.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -40,8 +41,10 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import cz.preclikos.tvhstream.R
 import cz.preclikos.tvhstream.models.RailItem
 import cz.preclikos.tvhstream.ui.screens.SettingsRoutes
 
@@ -54,12 +57,18 @@ fun SettingsSubRail(
 ) {
     var railFocused by remember { mutableStateOf(false) }
 
-    val items = remember {
+    val languageLabel = stringResource(R.string.navigation_language)
+    val connectionLabel = stringResource(R.string.navigation_connection)
+    val playerLabel = stringResource(R.string.navigation_player)
+    val items = remember(languageLabel, connectionLabel, playerLabel) {
         listOf(
-            RailItem(SettingsRoutes.CONNECTION, "Connection") {
+            RailItem(SettingsRoutes.GENERAL, languageLabel) {
+                Icon(Icons.Filled.Language, null, tint = Color.White)
+            },
+            RailItem(SettingsRoutes.CONNECTION, connectionLabel) {
                 Icon(Icons.AutoMirrored.Filled.List, null, tint = Color.White)
             },
-            RailItem(SettingsRoutes.PLAYER, "Player") {
+            RailItem(SettingsRoutes.PLAYER, playerLabel) {
                 Icon(Icons.Filled.PlayArrow, null, tint = Color.White)
             }
         )

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/components/SideRail.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/components/SideRail.kt
@@ -43,8 +43,10 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
+import cz.preclikos.tvhstream.R
 import cz.preclikos.tvhstream.models.RailItem
 import cz.preclikos.tvhstream.ui.Routes
 
@@ -64,17 +66,20 @@ fun SideRail(
         label = "railWidth"
     )
 
-    val items = remember {
+    val channelsLabel = stringResource(R.string.navigation_channels)
+    val epgLabel = stringResource(R.string.navigation_epg)
+    val settingsLabel = stringResource(R.string.navigation_settings)
+    val items = remember(channelsLabel, epgLabel, settingsLabel) {
         listOf(
-            RailItem(Routes.CHANNELS, "Channels") {
+            RailItem(Routes.CHANNELS, channelsLabel) {
                 Icon(
                     Icons.AutoMirrored.Filled.List,
                     null,
                     tint = Color.White
                 )
             },
-            RailItem(Routes.EPG, "EPG") { Icon(Icons.Filled.Event, null, tint = Color.White) },
-            RailItem(Routes.SETTINGS, "Settings") {
+            RailItem(Routes.EPG, epgLabel) { Icon(Icons.Filled.Event, null, tint = Color.White) },
+            RailItem(Routes.SETTINGS, settingsLabel) {
                 Icon(
                     Icons.Filled.Settings,
                     null,

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/player/OverlayControlsTv.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/player/OverlayControlsTv.kt
@@ -210,7 +210,12 @@ fun OverlayControlsTv(
 
 
                         RoundIconButton(
-                            icon = { Icon(Icons.Filled.Stop, contentDescription = "Stop") },
+                            icon = {
+                                Icon(
+                                    Icons.Filled.Stop,
+                                    contentDescription = stringResource(R.string.stop),
+                                )
+                            },
                             onClick = { onUserInteraction(); onBack() },
                             focusRequester = stopFR,
                             onFocused = { lastFocused = 0 }
@@ -303,7 +308,7 @@ fun OverlayControlsTv(
                                 icon = {
                                     Icon(
                                         Icons.AutoMirrored.Filled.VolumeUp,
-                                        contentDescription = "Audio"
+                                        contentDescription = stringResource(R.string.audio_track)
                                     )
                                 },
                                 onClick = { onUserInteraction(); showAudio = true },
@@ -314,7 +319,7 @@ fun OverlayControlsTv(
                                 icon = {
                                     Icon(
                                         Icons.Filled.Subtitles,
-                                        contentDescription = "Subtitles"
+                                        contentDescription = stringResource(R.string.subtitles)
                                     )
                                 },
                                 onClick = { onUserInteraction(); showSubs = true },

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/screens/EpgGridScreen.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/screens/EpgGridScreen.kt
@@ -52,9 +52,11 @@ import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import cz.preclikos.tvhstream.R
 import cz.preclikos.tvhstream.htsp.ChannelUi
 import cz.preclikos.tvhstream.htsp.EpgEventEntry
 import cz.preclikos.tvhstream.repositories.TvhRepository
@@ -170,7 +172,7 @@ fun EpgGridScreen(
             .padding(14.dp)
     ) {
         Text(
-            text = "EPG",
+            text = stringResource(R.string.epg_title),
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onBackground
         )

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/screens/SettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.navigation.compose.rememberNavController
 import cz.preclikos.tvhstream.ui.Routes
 import cz.preclikos.tvhstream.ui.components.SettingsSubRail
 import cz.preclikos.tvhstream.ui.screens.settings.SettingsConnection
+import cz.preclikos.tvhstream.ui.screens.settings.SettingsLanguage
 import cz.preclikos.tvhstream.ui.screens.settings.SettingsPlayer
 
 object SettingsRoutes {
@@ -77,6 +78,10 @@ fun SettingsScreen() {
                     navController = nav,
                     startDestination = SettingsRoutes.CONNECTION,
                 ) {
+                    composable(SettingsRoutes.GENERAL) {
+                        SettingsLanguage()
+                    }
+
                     composable(SettingsRoutes.CONNECTION) {
                         SettingsConnection()
                     }

--- a/app/src/main/java/cz/preclikos/tvhstream/ui/screens/settings/SettingsLanguage.kt
+++ b/app/src/main/java/cz/preclikos/tvhstream/ui/screens/settings/SettingsLanguage.kt
@@ -1,0 +1,79 @@
+package cz.preclikos.tvhstream.ui.screens.settings
+
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.selection.selectableGroup
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.unit.dp
+import androidx.core.os.LocaleListCompat
+import cz.preclikos.tvhstream.R
+import cz.preclikos.tvhstream.settings.AppLanguage
+
+@Composable
+fun SettingsLanguage() {
+    val selected = AppLanguage.fromLanguageTags(
+        AppCompatDelegate.getApplicationLocales().toLanguageTags()
+    )
+    val options = listOf(
+        AppLanguage.SYSTEM to stringResource(R.string.language_follow_system),
+        AppLanguage.GERMAN to stringResource(R.string.language_german),
+        AppLanguage.ENGLISH to stringResource(R.string.language_english),
+        AppLanguage.CZECH to stringResource(R.string.language_czech),
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.settings_language),
+            style = MaterialTheme.typography.titleLarge,
+            modifier = Modifier.padding(top = 10.dp),
+        )
+
+        Column(Modifier.selectableGroup()) {
+            options.forEach { (language, label) ->
+                Row(
+                    modifier = Modifier
+                        .selectable(
+                            selected = language == selected,
+                            onClick = {
+                                if (language != selected) {
+                                    AppCompatDelegate.setApplicationLocales(
+                                        LocaleListCompat.forLanguageTags(language.languageTag)
+                                    )
+                                }
+                            },
+                            role = Role.RadioButton,
+                        )
+                        .padding(horizontal = 8.dp, vertical = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(
+                        selected = language == selected,
+                        onClick = null,
+                    )
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.bodyLarge,
+                        modifier = Modifier.padding(start = 10.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1,6 +1,13 @@
 <resources>
     <string name="channel_list">Seznam kanálů</string>
 
+    <string name="navigation_channels">Kanály</string>
+    <string name="navigation_epg">Program</string>
+    <string name="navigation_settings">Nastavení</string>
+    <string name="navigation_language">Jazyk</string>
+    <string name="navigation_connection">Připojení</string>
+    <string name="navigation_player">Přehrávač</string>
+
     <string name="player_ends_in">Končí v: %1$s</string>
     <string name="player_next_event">Následuje: %1$s</string>
     <string name="player_next_event_with_range">Následuje: %1$s • %2$s</string>
@@ -15,6 +22,11 @@
 
     <!-- Settings screen -->
     <string name="settings_server">Nastavení – Připojení</string>
+    <string name="settings_language">Nastavení – Jazyk</string>
+    <string name="language_follow_system">Podle systému</string>
+    <string name="language_german">Němčina</string>
+    <string name="language_english">Angličtina</string>
+    <string name="language_czech">Čeština</string>
     <string name="host">Host</string>
     <string name="port_htsp">Htsp Port</string>
     <string name="port_http">Http Port</string>
@@ -59,6 +71,7 @@
     <string name="epg_loading">Načítání programu…</string>
 
     <string name="play">Přehrát</string>
+    <string name="stop">Zastavit</string>
 
     <string name="tvh_target_invalid">Neplatný cíl streamu</string>
     <string name="tvh_no_free_adapter">Není volný tuner</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,84 @@
+<resources>
+    <string name="channel_list">Senderliste</string>
+
+    <string name="navigation_channels">Sender</string>
+    <string name="navigation_epg">Programm</string>
+    <string name="navigation_settings">Einstellungen</string>
+    <string name="navigation_language">Sprache</string>
+    <string name="navigation_connection">Verbindung</string>
+    <string name="navigation_player">Wiedergabe</string>
+
+    <string name="player_ends_in">Endet um %1$s</string>
+    <string name="player_next_event">Als Nächstes: %1$s</string>
+    <string name="player_next_event_with_range">Als Nächstes: %1$s • %2$s</string>
+
+    <string name="options">Optionen</string>
+    <string name="no_epg">Keine Programmdaten</string>
+    <string name="epg_next">Danach um %1$s</string>
+    <string name="select_channel_hint">Wählen Sie links einen Sender aus, um Details anzuzeigen.</string>
+
+    <string name="epg_time_duration">Zeit: %1$s – %2$s • Dauer: %3$d Min.</string>
+
+    <string name="settings_server">Einstellungen – Verbindung</string>
+    <string name="settings_language">Einstellungen – Sprache</string>
+    <string name="language_follow_system">Systemsprache verwenden</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_english">Englisch</string>
+    <string name="language_czech">Tschechisch</string>
+    <string name="host">Host</string>
+    <string name="port_htsp">HTSP-Port</string>
+    <string name="port_http">HTTP-Port</string>
+    <string name="username">Benutzername</string>
+    <string name="password">Passwort</string>
+
+    <string name="settings_player">Einstellungen – Wiedergabe</string>
+    <string name="profile">Profil</string>
+    <string name="audio_language">Audiosprache</string>
+    <string name="subtitle_language">Untertitelsprache</string>
+
+    <string name="loading_wait">Warten auf Ladevorgang…</string>
+    <string name="not_connected">Nicht verbunden</string>
+    <string name="loading">Wird geladen…</string>
+    <string name="loading_error">Fehler beim Laden</string>
+    <string name="select_profile">Profil auswählen</string>
+
+    <string name="error_prefix">Fehler:</string>
+
+    <string name="save">Speichern</string>
+    <string name="back">Zurück</string>
+
+    <string name="show_password">Passwort anzeigen</string>
+    <string name="hide_password">Passwort ausblenden</string>
+
+    <string name="audio_track">Tonspur</string>
+    <string name="no_audio_tracks">Keine Tonspuren verfügbar.</string>
+
+    <string name="subtitles">Untertitel</string>
+    <string name="subtitles_off">Aus</string>
+    <string name="no_subtitles">Keine Untertitel verfügbar.</string>
+
+    <string name="close">Schließen</string>
+
+    <string name="epg_title">Programm</string>
+    <string name="epg_schedule">Programmübersicht</string>
+    <string name="epg_loading">Programm wird geladen…</string>
+
+    <string name="play">Abspielen</string>
+    <string name="stop">Beenden</string>
+
+    <string name="tvh_target_invalid">Ungültiges Streaming-Ziel</string>
+    <string name="tvh_no_free_adapter">Kein freier Tuner verfügbar</string>
+    <string name="tvh_mux_not_enabled">Multiplex ist nicht aktiviert</string>
+    <string name="tvh_tuning_failed">Sender konnte nicht eingestellt werden</string>
+    <string name="tvh_bad_signal">Schlechtes Signal</string>
+    <string name="tvh_scrambled">Sender ist verschlüsselt</string>
+    <string name="tvh_subscription_overridden">Stream-Anforderung wurde überschrieben</string>
+    <string name="tvh_no_input">Kein Eingangssignal</string>
+
+    <string name="status_epg_loading">Programm wird geladen…</string>
+    <string name="status_epg_warmup">Programmdaten: %1$d/%2$d geladen</string>
+    <string name="status_epg_steady_warmup">Programm: bereit (%1$d/%2$d geladen)</string>
+    <string name="status_epg_warmup_batch">Programmdaten: %1$d/%2$d geladen (%3$d/%4$d aktualisiert)</string>
+    <string name="status_channels_ready">Sender verfügbar: %1$d</string>
+    <string name="status_syncing_channels">Sender werden synchronisiert… %1$d</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,13 @@
 
     <string name="channel_list">Channel List</string>
 
+    <string name="navigation_channels">Channels</string>
+    <string name="navigation_epg">EPG</string>
+    <string name="navigation_settings">Settings</string>
+    <string name="navigation_language">Language</string>
+    <string name="navigation_connection">Connection</string>
+    <string name="navigation_player">Player</string>
+
     <string name="player_ends_in">Ends at: %1$s</string>
     <string name="player_next_event">Up next: %1$s</string>
     <string name="player_next_event_with_range">Up next: %1$s • %2$s</string>
@@ -17,6 +24,11 @@
 
     <!-- Settings screen -->
     <string name="settings_server">Settings - Connection</string>
+    <string name="settings_language">Settings - Language</string>
+    <string name="language_follow_system">Follow system</string>
+    <string name="language_german">German</string>
+    <string name="language_english">English</string>
+    <string name="language_czech">Czech</string>
     <string name="host">Host</string>
     <string name="port_htsp">Htsp Port</string>
     <string name="port_http">Http Port</string>
@@ -62,6 +74,7 @@
     <string name="epg_loading">Loading EPG…</string>
 
     <string name="play">Play</string>
+    <string name="stop">Stop</string>
 
     <string name="tvh_target_invalid">Streaming target invalid</string>
     <string name="tvh_no_free_adapter">No free tuner available</string>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="en" />
+    <locale android:name="de" />
+    <locale android:name="cs" />
+</locale-config>

--- a/app/src/test/java/cz/preclikos/tvhstream/settings/AppLanguageTest.kt
+++ b/app/src/test/java/cz/preclikos/tvhstream/settings/AppLanguageTest.kt
@@ -1,0 +1,24 @@
+package cz.preclikos.tvhstream.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppLanguageTest {
+    @Test
+    fun chooserLanguages_mapToAndroidLanguageTags() {
+        assertEquals("", AppLanguage.SYSTEM.languageTag)
+        assertEquals("de", AppLanguage.GERMAN.languageTag)
+        assertEquals("en", AppLanguage.ENGLISH.languageTag)
+        assertEquals("cs", AppLanguage.CZECH.languageTag)
+    }
+
+    @Test
+    fun currentLanguageTag_mapsToChooserLanguage() {
+        assertEquals(AppLanguage.SYSTEM, AppLanguage.fromLanguageTags(""))
+        assertEquals(AppLanguage.GERMAN, AppLanguage.fromLanguageTags("de"))
+        assertEquals(AppLanguage.GERMAN, AppLanguage.fromLanguageTags("de-DE"))
+        assertEquals(AppLanguage.ENGLISH, AppLanguage.fromLanguageTags("en-GB"))
+        assertEquals(AppLanguage.CZECH, AppLanguage.fromLanguageTags("cs-CZ"))
+        assertEquals(AppLanguage.SYSTEM, AppLanguage.fromLanguageTags("fr"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a complete German translation for all translatable upstream resources
- add an in-app language screen for System default, German, English, and Czech
- persist app locales through AndroidX AppCompat and declare supported locales to Android
- localize navigation, EPG title, and playback accessibility labels that were previously hardcoded
- exclude all fork-specific appliance strings and documentation

## Verification
- focused `AppLanguageTest`
- full `testDebugUnitTest`
- `assembleDebug`
- resource-key review: all 65 translatable upstream keys have German values

The public checkout has no `google-services.json`, so Firebase plugins/dependencies were disabled only for local verification and restored before committing.

Closes #17